### PR TITLE
Add support for running tests in parallel

### DIFF
--- a/src/cleantest/control/configurator.py
+++ b/src/cleantest/control/configurator.py
@@ -30,7 +30,7 @@ class Configure:
     __hook_registry = HookRegistry()
     __metadata = set()
 
-    def __new__(cls) -> None:
+    def __new__(cls) -> "Configure":
         if not hasattr(cls, "instance"):
             cls.instance = super(Configure, cls).__new__(cls)
         return cls.instance

--- a/src/cleantest/pkg/handler/__init__.py
+++ b/src/cleantest/pkg/handler/__init__.py
@@ -2,4 +2,4 @@
 # Copyright 2022 Jason C. Nucciarone, Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import snap_handler as snap
+import cleantest.pkg.handler.snap_handler as snap

--- a/src/cleantest/provider/_handler/__init__.py
+++ b/src/cleantest/provider/_handler/__init__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022 Jason C. Nucciarone, Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from .lxd_handler import LXDHandler
+from .base_handler import Result
+from .lxd_handler import LXDProvider

--- a/src/cleantest/provider/_handler/base_handler.py
+++ b/src/cleantest/provider/_handler/base_handler.py
@@ -94,11 +94,11 @@ class Handler(ABC):
             )
         )
 
-    def _construct_testlet(self, func: Callable, remove: List[re.Pattern] | None) -> str:
+    def _construct_testlet(self, src: str, name: str, remove: List[re.Pattern] | None) -> str:
         """Construct Python source file to be run in subroutine.
 
         Args:
-            func (Callable): TODO
+            src (str): TODO
             remove (List[re.Pattern]): TODO
 
         Returns:
@@ -108,7 +108,6 @@ class Handler(ABC):
             This will need more advanced logic if tests accept arguments.
         """
         try:
-            src = inspect.getsource(func)
             if remove is not None:
                 for pattern in remove:
                     src = re.sub(pattern, "", src)
@@ -117,7 +116,7 @@ class Handler(ABC):
                 content = [
                     "#!/usr/bin/env python3\n",
                     f"{src}\n",
-                    f"{func.__name__}()\n",
+                    f"{name}()\n",
                 ]
                 f.writelines(content)
                 f.seek(0)
@@ -125,7 +124,7 @@ class Handler(ABC):
 
             return scriptlet
         except OSError:
-            raise HandlerError(f"Could not locate source code for testlet {func.__name__}.")
+            raise HandlerError(f"Could not locate source code for testlet {name}.")
 
     def _construct_pkg_installer(self, pkg: object, file_path: str, hash: str) -> str:
         src = inspect.getsourcefile(pkg.__class__)

--- a/src/cleantest/provider/_handler/base_handler.py
+++ b/src/cleantest/provider/_handler/base_handler.py
@@ -14,9 +14,8 @@ import tarfile
 import tempfile
 import textwrap
 from abc import ABC, abstractmethod
-from typing import Any, Callable, List
-
-from pydantic import BaseModel
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List
 
 import cleantest
 
@@ -25,18 +24,29 @@ class HandlerError(Exception):
     ...
 
 
-class Result(BaseModel):
-    exit_code: int | None = None
-    stdout: Any | None = None
-    stderr: Any | None = None
+@dataclass
+class Result:
+    exit_code: int = None
+    stdout: Any = None
+    stderr: Any = None
+
+
+class Entrypoint(ABC):
+    """Abstract super-class for test environment provider entrypoints.
+
+    Entrypoints define the tooling needed by cleantest to start a test.
+    """
+
+    @abstractmethod
+    def run(self) -> Dict[str, Result]:
+        ...
 
 
 class Handler(ABC):
-    """Abstract super-class for all test environment providers."""
+    """Abstract super-class for test environment handlers.
 
-    @abstractmethod
-    def run(self) -> Result:
-        ...
+    Handlers define all the tooling needed to run tests inside the remote environment.
+    """
 
     @abstractmethod
     def _init(self) -> None:

--- a/src/cleantest/provider/_handler/lxd_handler.py
+++ b/src/cleantest/provider/_handler/lxd_handler.py
@@ -5,75 +5,36 @@
 """Handler for LXD-based test environments."""
 
 import json
+import multiprocessing
 import os
 import re
+from dataclasses import dataclass
 from typing import Any, Callable, Dict, List
 
-from pydantic import BaseModel
-
 from cleantest.pkg._base import Package
-from cleantest.provider._handler.base_handler import Handler, Result
+from cleantest.provider._handler.base_handler import Entrypoint, Handler, Result
 from cleantest.provider.data.lxd_data import LXDConfig
 
 
-class Instance(BaseModel):
+@dataclass
+class Instance:
     name: str
     image: str
     exists: bool = False
 
 
 class LXDHandler(Handler):
-    def __init__(self, attr: Dict[str, Any], func: Callable, threaded: bool) -> None:
-        [setattr(self, k, v) for k, v in attr.items()]
-        self.func = func
-        self.threaded = threaded
-
-    @classmethod
-    def serial(cls, lxd, func: Callable) -> object:
-        return cls(lxd.__dict__, func, False)
-
-    @classmethod
-    def parallel(cls, lxd, func: Callable) -> object:
-        return cls(lxd.__dict__, func, True)
-
-    def run(self) -> Result:
-        instances = []
-        for i in self._image:
-            instances.append(Instance(name=f"{self._name}-{i}", image=i))
-
-        self._build(self._check_exists(instances))
-        self._handle_start_env_hooks(instances)
-        result = self._execute(
-            self._construct_testlet(self.func, [re.compile("@lxd(.*)")]), instances
-        )
-        if self._preserve is False:
-            self._teardown(instances)
-
-        return self._process(result)
-
-    def _check_exists(self, instances: List[Instance]) -> List[Instance]:
-        exists_status = []
-        for i in instances:
-            if self._client.instances.exists(i.name):
-                i.exists = True
-                exists_status.append(i)
-            else:
-                exists_status.append(i)
-
-        return exists_status
-
-    def _build(self, instances: List[Instance]) -> None:
-        for i in instances:
-            if i.exists is False:
-                config = self._data.get_config(i.image)
-                config.name = i.name
-                self._client.instances.create(config.dict(), wait=True)
-                instance = self._client.instances.get(i.name)
-                instance.start(wait=True)
-                self._init(instance, config)
-            else:
-                if (tmp := self._client.instances.get(i.name)).status.lower() == "stopped":
-                    tmp.start(wait=True)
+    def _build(self, instance: Instance) -> None:
+        if instance.exists is False:
+            config = self._data.get_config(instance.image)
+            config.name = instance.name
+            self._client.instances.create(config.dict(), wait=True)
+            instance = self._client.instances.get(instance.name)
+            instance.start(wait=True)
+            self._init(instance, config)
+        else:
+            if (tmp := self._client.instances.get(instance.name)).status.lower() == "stopped":
+                tmp.start(wait=True)
 
     def _init(self, instance: Any, config: LXDConfig) -> None:
         if "ubuntu" in config.source.alias:
@@ -89,33 +50,27 @@ class LXDHandler(Handler):
         else:
             NotImplementedError(f"{config.source.alias} injection not supported yet.")
 
-    def _execute(self, test: str, instances: List[Instance]) -> Any:
-        for i in instances:
-            instance = self._client.instances.get(i.name)
-            instance.files.put("/root/test", test)
-            instance.execute(["chmod", "+x", "/root/test"])
-            return instance.execute(["/root/test"], environment=self._env.dump())
+    def _execute(self, test: str, instance: Instance) -> Any:
+        instance = self._client.instances.get(instance.name)
+        instance.files.put("/root/test", test)
+        instance.execute(["chmod", "+x", "/root/test"])
+        return instance.execute(["/root/test"], environment=self._env.dump())
 
-    def _process(self, result: Any) -> Result:
-        return Result(exit_code=result.exit_code, stdout=result.stdout, stderr=result.stderr)
+    def _teardown(self, instance: Instance) -> None:
+        instance = self._client.instance.get(instance.name)
+        instance.stop(wait=True)
+        instance.delete(wait=True)
 
-    def _teardown(self, instances: List[Instance]) -> None:
-        for i in instances:
-            instance = self._client.instances.get(i.name)
-            instance.stop(wait=True)
-            instance.delete(wait=True)
+    def _handle_start_env_hooks(self, instance: Instance) -> None:
+        start_env_hooks = self._cleanconfig.get_start_env_hooks()
+        while len(start_env_hooks) > 0:
+            hook = start_env_hooks.pop()
+            instance = self._client.instances.get(instance.name)
+            if hook.packages is not None:
+                for pkg in hook.packages:
+                    self._handle_package_install(instance, pkg)
 
-    def _handle_start_env_hooks(self, instances: List[Instance]) -> None:
-        startenvhooks = self._cleanconfig.get_start_env_hooks()
-        while len(startenvhooks) > 0:
-            hook = startenvhooks.pop()
-            for i in instances:
-                instance = self._client.instances.get(i.name)
-                if hook.packages is not None:
-                    for pkg in hook.packages:
-                        self.__handle_package_install(instance, pkg)
-
-    def __handle_package_install(self, instance: Any, pkg: Package) -> None:
+    def _handle_package_install(self, instance: Any, pkg: Package) -> None:
         dispatch = {"charmlib": lambda x: self._env.add(json.loads(x))}
 
         dump_data = pkg._dump()
@@ -130,3 +85,64 @@ class LXDHandler(Handler):
 
         if (tmp := pkg.__class__.__name__.lower()) in dispatch:
             dispatch[tmp](result.stdout)
+
+    def _process(self, result: Any) -> Result:
+        return Result(exit_code=result.exit_code, stdout=result.stdout, stderr=result.stderr)
+
+    def _check_exists(self, instance: Instance) -> Instance:
+        if self._client.instances.exists(instance.name):
+            instance.exists = True
+
+        return instance
+
+    def _construct_instance_metaclasses(self) -> List[Instance]:
+        return [Instance(name=f"{self._name}-{i}", image=i) for i in self._image]
+
+
+class Serial(Entrypoint, LXDHandler):
+    def __init__(self, attr: Dict[str, Any], func: Callable) -> None:
+        # TODO: Consider replacing the mount with explicit values.
+        [setattr(self, k, v) for k, v in attr.items()]
+        self.func = func
+
+    def run(self) -> Dict[str, Result]:
+        results = {}
+        for i in self._construct_instance_metaclasses():
+            self._build(self._check_exists(i))
+            self._handle_start_env_hooks(i)
+            result = self._execute(
+                self._construct_testlet(self.func, [re.compile("@lxd(.*)")]), i
+            )
+            if self._preserve is False:
+                self._teardown(i)
+            results.update({i.name: self._process(result)})
+
+        return results
+
+
+class Parallel(Entrypoint, LXDHandler):
+    def __init__(self, attr: Dict[str, Any], func: Callable) -> None:
+        # TODO: Consider replacing the mount with explicit values.
+        [setattr(self, k, v) for k, v in attr.items()]
+        self.func = func
+
+    def run(self) -> Dict[str, Result]:
+        # TODO: Polish off multiprocessing for LXD tests.
+        #   Data will need to be massaged so it can return in the proper format.
+        # pool = multiprocessing.Pool(processes=4)
+        # results = pool.map(self._target, self._construct_instance_metaclasses())
+        ...
+
+    def _target(self):
+        # TODO: Test that methods defined in classes can serve as targets.
+        ...
+
+
+class LXDProvider:
+    @staticmethod
+    def serial(lxd, func: Callable) -> "Serial":
+        return Serial(lxd.__dict__, func)
+
+    @staticmethod
+    def parallel(lxd, func: Callable) -> "Parallel":
+        return Parallel(lxd.__dict__, func)

--- a/src/cleantest/provider/lxd.py
+++ b/src/cleantest/provider/lxd.py
@@ -10,8 +10,6 @@ import os
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Tuple
 
-from pylxd import Client
-
 from cleantest.control.configurator import Configure
 from cleantest.provider.data import EnvDataStore, LXDDataStore
 
@@ -46,7 +44,8 @@ class lxd:
         self._env = env
         self._data = data
         self._parallel = parallel
-        self._cleanconfig = Configure()
+        self._client_config = client_config
+        self._clean_config = Configure()
 
         if type(image) == str:
             self._image = [image]
@@ -58,18 +57,6 @@ class lxd:
         elif type(image_config) == list:
             for c in image_config:
                 self._data.add_config(c)
-
-        if client_config is None:
-            self._client = Client(project="default")
-        else:
-            self._client = Client(
-                endpoint=client_config.endpoint,
-                version=client_config.version,
-                cert=client_config.cert,
-                verify=client_config.verify,
-                timeout=client_config.timeout,
-                project=client_config.project,
-            )
 
         if (type(num_threads) != int or num_threads < 1) and self._parallel is True:
             env_var = os.getenv("CLEANTEST_NUM_THREADS")

--- a/src/cleantest/utils/__init__.py
+++ b/src/cleantest/utils/__init__.py
@@ -2,4 +2,4 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from .detect_os import detect_os_variant
+from cleantest.utils.detect_os import detect_os_variant

--- a/tests/lxd/local/test_lxd_local.py
+++ b/tests/lxd/local/test_lxd_local.py
@@ -26,6 +26,7 @@ startenvhook = StartEnvHook(
 )
 cleanconfig.register_hook(startenvhook)
 
+
 # Define the testlets.
 @lxd(image="jammy-amd64", preserve=False)
 def install_snapd():
@@ -65,5 +66,6 @@ def install_snapd():
 # Run the tests through pytest.
 class TestLocalLXD:
     def test_local_lxd(self) -> None:
-        result = install_snapd()
-        assert result.exit_code == 0
+        results = install_snapd()
+        for name, result in results.items():
+            assert result.exit_code == 0

--- a/tests/lxd/parallel/test_lxd_parallel.py
+++ b/tests/lxd/parallel/test_lxd_parallel.py
@@ -1,3 +1,41 @@
 #!/usr/bin/env python3
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022 Jason C. Nucciarone, Canonical Ltd.
 # See LICENSE file for licensing details.
+
+"""Test parallel testing capabilites of LXD provider using local LXD cluster."""
+
+from cleantest import Configure
+from cleantest.hooks import StartEnvHook
+from cleantest.pkg import Pip
+from cleantest.provider import lxd
+
+cleantest_config = Configure()
+start_hook = StartEnvHook(name="pip_injection", packages=[Pip(packages="tabulate")])
+cleantest_config.register_hook(start_hook)
+
+
+@lxd(
+    image=["jammy-amd64", "focal-amd64", "bionic-amd64"],
+    preserve=True,
+    parallel=True,
+    num_threads=2,
+)
+def install_tabulate():
+    import sys
+
+    try:
+        from tabulate import tabulate
+
+        print("tabulate is installed.", file=sys.stdout)
+    except ImportError:
+        print("Failed to import tabulate package.", file=sys.stderr)
+        sys.exit(1)
+
+    sys.exit(0)
+
+
+class TestParallelLXD:
+    def test_parallel_lxd(self) -> None:
+        results = install_tabulate()
+        for name, result in results.items():
+            assert result.exit_code == 0

--- a/tests/packages/snap/test_snap.py
+++ b/tests/packages/snap/test_snap.py
@@ -43,5 +43,6 @@ def functional_snaps():
 
 class TestLocalLXD:
     def test_snap_package(self) -> None:
-        result = functional_snaps()
-        assert result.exit_code == 0
+        results = functional_snaps()
+        for name, result in results.items():
+            assert result.exit_code == 0

--- a/tox.ini
+++ b/tox.ini
@@ -87,6 +87,12 @@ commands =
 
 [testenv:lxd-local-parallel]
 description = Run functional tests in parallel for a locally-hosted LXD cluster.
+deps =
+  -r {toxinidir}/requirements.txt
+  pytest
+  pylxd
+commands =
+  pytest -v --tb native --log-cli-level=ERROR {[vars]tst_path}/lxd/parallel
 
 [testenv:lxd-remote]
 description = Run functional tests for a remotely-hosted LXD cluster.


### PR DESCRIPTION
This pull request has added support for running tests in parallel instances rather than sequentially proceeding through each instance. Some things had to be changed so that parallel testing could be supported:

* Result from testlet is now returned as `Dict[str, Result]` rather than just result. This allows looping to see which tests passed on which OSes and which did not/
* `Client` (what connects to the LXD socket) is now created by `LXDHandler` rather than `lxd`. This was done because a part of `Client` (see comment in #3) could not be pickled.
* The source code and name for testlet is retrieved preemptively by either `Serial` and `Parallel`. This change was added because the testlet could not be pickled while being sent through the process pool.
* There are now five classes in *lxd_handler.py*:
  * `LXDProvider` -> returns either serial or parallel LXD handler by request.
  * `Serial` -> test handler if only using single thread.
  * `Parallel` -> test handler if using multiple threads.
  * `LXDHandler` -> a mixin that provides all the core utilities needed to run tests.
* A new abstract class has been added to *base_handler.py*:
  * `Entrypoint` -> defines that all test handlers should implement the `run()` method.

### Next steps

* cleantest needs to be modified so it can interoperate with older distros. I like my type annotations, but it prevents cleantest from working on versions older than 3.8. I aim to add support for Xenial and Bionic as well.

### Related issues

Closes #3 