### PR TITLE
Retrofit cleantest to support Python 3.6 and up

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Here are my (NucciTheBoss's) goals to get cleantest to release version 1.0.0:
   * Rocky
   * Fedora
   * Arch
-* Enable support for running parallel tests with LXD
+* ~~Enable support for running parallel tests with LXD~~
 * Better test logging capabilities
 * Support for a select few popular packaging formats:
   * ~~Snap~~

--- a/src/cleantest/control/configurator.py
+++ b/src/cleantest/control/configurator.py
@@ -1,15 +1,11 @@
 #!/usr/bin/env python3
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022 Jason C. Nucciarone, Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Manage the state and flow of cleantest."""
 
-from __future__ import annotations
-
 from collections import deque
-from typing import Deque
-
-from pydantic import BaseModel
+from typing import Deque, Union
 
 from cleantest.hooks import StartEnvHook, StartTestletHook, StopEnvHook, StopTestletHook
 
@@ -18,7 +14,7 @@ class DuplicateHookNameError(Exception):
     ...
 
 
-class HookRegistry(BaseModel):
+class HookRegistry:
     start_env: Deque[StartEnvHook] = deque()
     stop_env: Deque[StopEnvHook] = deque()
     start_testlet: Deque[StartTestletHook] = deque()
@@ -36,7 +32,7 @@ class Configure:
         return cls.instance
 
     def register_hook(
-        self, hook: StartEnvHook | StopEnvHook | StartTestletHook | StopTestletHook
+        self, hook: Union[StartEnvHook, StopEnvHook, StartTestletHook, StopTestletHook]
     ) -> None:
         lint = [
             h for h in self.__metadata if hook.name == h[0] and hook.__class__.__name__ == h[1]

--- a/src/cleantest/control/configurator.py
+++ b/src/cleantest/control/configurator.py
@@ -4,6 +4,7 @@
 
 """Manage the state and flow of cleantest."""
 
+import copy
 from collections import deque
 from typing import Deque, Union
 
@@ -63,16 +64,16 @@ class Configure:
                 dispatch[hook[1]].remove(hook_name)
 
     def get_start_env_hooks(self) -> Deque[StartEnvHook]:
-        return self.__hook_registry.start_env
+        return copy.deepcopy(self.__hook_registry.start_env)
 
     def get_stop_env_hooks(self) -> Deque[StopEnvHook]:
-        return self.__hook_registry.stop_env
+        return copy.deepcopy(self.__hook_registry.stop_env)
 
     def get_start_testlet_hooks(self) -> Deque[StartTestletHook]:
-        return self.__hook_registry.start_testlet
+        return copy.deepcopy(self.__hook_registry.start_testlet)
 
     def get_stop_testlet_hooks(self) -> Deque[StopTestletHook]:
-        return self.__hook_registry.stop_testlet
+        return copy.deepcopy(self.__hook_registry.stop_testlet)
 
     @property
     def _hook_registry(self) -> HookRegistry:

--- a/src/cleantest/hooks/startenv.py
+++ b/src/cleantest/hooks/startenv.py
@@ -4,8 +4,6 @@
 
 """Hook run when test environment first starts."""
 
-from __future__ import annotations
-
 from typing import List
 
 

--- a/src/cleantest/hooks/startenv.py
+++ b/src/cleantest/hooks/startenv.py
@@ -8,9 +8,8 @@ from __future__ import annotations
 
 from typing import List
 
-from pydantic import BaseModel
 
-
-class StartEnvHook(BaseModel):
-    name: str = "default"
-    packages: List[object] = []
+class StartEnvHook:
+    def __init__(self, name: str = "default", packages: List[object] = []):
+        self.name = name
+        self.packages = packages

--- a/src/cleantest/hooks/starttestlet.py
+++ b/src/cleantest/hooks/starttestlet.py
@@ -4,11 +4,9 @@
 
 """Hook run before testlet starts but after StartEnv hook."""
 
-from pydantic import BaseModel
 
-
-class StartTestletHook(BaseModel):
+class StartTestletHook:
     """Not implemented yet as I do not know if hooks are the move."""
 
-    def __init__(self) -> None:
+    def __init__(self):
         raise NotImplementedError("Hook not implemented yet.")

--- a/src/cleantest/hooks/stopenv.py
+++ b/src/cleantest/hooks/stopenv.py
@@ -4,11 +4,9 @@
 
 """Hook run before test environment stops."""
 
-from pydantic import BaseModel
 
-
-class StopEnvHook(BaseModel):
+class StopEnvHook:
     """Not implemented yet as I do not know if hooks are the move."""
 
-    def __init__(self) -> None:
+    def __init__(self):
         raise NotImplementedError("Hook not implemented yet.")

--- a/src/cleantest/hooks/stoptestlet.py
+++ b/src/cleantest/hooks/stoptestlet.py
@@ -4,11 +4,9 @@
 
 """Hook run after testlet finishes but before StopEnv hook."""
 
-from pydantic import BaseModel
 
-
-class StopTestletHook(BaseModel):
+class StopTestletHook:
     """Not implemented yet as I do not know if hooks are the move."""
 
-    def __init__(self) -> None:
+    def __init__(self):
         raise NotImplementedError("Hook not implemented yet.")

--- a/src/cleantest/pkg/_base.py
+++ b/src/cleantest/pkg/_base.py
@@ -4,8 +4,6 @@
 
 """Base package class for installing packages inside remote processes."""
 
-from __future__ import annotations
-
 import hashlib
 import os
 import pathlib

--- a/src/cleantest/pkg/charmlib.py
+++ b/src/cleantest/pkg/charmlib.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python3
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022 Jason C. Nucciarone, Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Manager for installing charm libraries inside remote processes."""
 
-from __future__ import annotations
-
 import json
 import subprocess
 from shutil import which
-from typing import List
+from typing import List, Union
 
 from cleantest.pkg._base import Package, PackageError
 from cleantest.utils import detect_os_variant
@@ -19,7 +17,7 @@ class Charmlib(Package):
     def __init__(
         self,
         auth_token_path: str = None,
-        charmlibs: str | List[str] = None,
+        charmlibs: Union[str, List[str]] = None,
         _manager: "Charmlib" = None,
     ) -> None:
         if _manager is None:

--- a/src/cleantest/pkg/handler/__init__.py
+++ b/src/cleantest/pkg/handler/__init__.py
@@ -2,4 +2,4 @@
 # Copyright 2022 Jason C. Nucciarone, Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import cleantest.pkg.handler.snap_handler as snap
+from . import snap_handler as snap

--- a/src/cleantest/pkg/handler/snap_handler.py
+++ b/src/cleantest/pkg/handler/snap_handler.py
@@ -18,7 +18,7 @@ from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from subprocess import CalledProcessError, CompletedProcess
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, Iterable, List, Optional, Union
 
 from cleantest.pkg._base import PackageError
 
@@ -502,7 +502,7 @@ class SnapClient:
         path: str,
         query: Dict = None,
         body: Dict = None,
-    ) -> dict | List:
+    ) -> Union[dict, List]:
         """Make a JSON request to the Snapd server with the given HTTP method and path.
 
         If query dict is provided, it is encoded and appended as a query string
@@ -665,12 +665,12 @@ class SnapCache(Mapping):
 
 @_cache_init
 def install(
-    snap_names: str | List[str],
-    state: str | SnapState = SnapState.LATEST,
+    snap_names: Union[str, List[str]],
+    state: Union[str, SnapState] = SnapState.LATEST,
     channel: Optional[str] = "latest",
     classic: Optional[bool] = False,
     cohort: Optional[str] = "",
-) -> Snap | List[Snap]:
+) -> Union[Snap, List[Snap]]:
     """Install a snap or snaps in a remote process.
 
     Args:
@@ -696,7 +696,7 @@ def install(
 
 
 @_cache_init
-def remove(snap_names: str | List[str]) -> Snap | List[Snap]:
+def remove(snap_names: Union[str, List[str]]) -> Union[Snap, List[Snap]]:
     """Removes a snap from the system.
 
     Args:
@@ -714,12 +714,12 @@ def remove(snap_names: str | List[str]) -> Snap | List[Snap]:
 
 @_cache_init
 def ensure(
-    snap_names: str | List[str],
+    snap_names: Union[str, List[str]],
     state: str,
     channel: Optional[str] = "latest",
     classic: Optional[bool] = False,
     cohort: Optional[str] = "",
-) -> Snap | List[Snap]:
+) -> Union[Snap, List[Snap]]:
     """Ensures a snap is in a given state to the system.
 
     Args:
@@ -745,7 +745,7 @@ def _wrap_snap_operations(
     channel: str,
     classic: bool,
     cohort: Optional[str] = "",
-) -> Snap | List[Snap]:
+) -> Union[Snap, List[Snap]]:
     """Wrap common operations for bare commands."""
     snaps = {"success": [], "failed": []}
 

--- a/src/cleantest/pkg/pip.py
+++ b/src/cleantest/pkg/pip.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python3
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022 Jason C. Nucciarone, Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Manager for installing pip packages inside remote processes."""
 
-from __future__ import annotations
-
 import pathlib
 import subprocess
 from shutil import which
-from typing import List
+from typing import List, Union
 
 from cleantest.pkg._base import Package, PackageError
 from cleantest.utils import detect_os_variant
@@ -18,9 +16,9 @@ from cleantest.utils import detect_os_variant
 class Pip(Package):
     def __init__(
         self,
-        packages: str | List[str] = None,
-        requirements: str | List[str] = None,
-        constraints: str | List[str] = None,
+        packages: Union[str, List[str]] = None,
+        requirements: Union[str, List[str]] = None,
+        constraints: Union[str, List[str]] = None,
         _manager: "Pip" = None,
     ) -> None:
         if _manager is None:
@@ -130,9 +128,9 @@ class Pip(Package):
 
     def _lint_inputs(
         self,
-        packages: str | List[str] | None,
-        requirements: str | List[str] | None,
-        constraints: str | List[str] | None,
+        packages: Union[str, List[str], None],
+        requirements: Union[str, List[str], None],
+        constraints: Union[str, List[str], None],
     ) -> None:
         lint_rules = [
             lambda: True if packages is None and requirements is None else False,

--- a/src/cleantest/pkg/snap.py
+++ b/src/cleantest/pkg/snap.py
@@ -4,14 +4,11 @@
 
 """Manager for installing snap packages inside remote processes."""
 
-from __future__ import annotations
-
 import pathlib
 import subprocess
-from dataclasses import dataclass
 from enum import Enum
 from shutil import which
-from typing import List
+from typing import List, Optional, Union
 
 from cleantest.pkg._base import Package, PackageError
 from cleantest.pkg.handler import snap
@@ -26,16 +23,16 @@ class Confinement(Enum):
     DEVMODE = "devmode"
 
 
-@dataclass
 class Plug:
-    snap: str
-    name: str
+    def __init__(self, snap: str, name: str) -> None:
+        self.snap = snap
+        self.name = name
 
 
-@dataclass
 class Slot:
-    snap: str = None
-    name: str = None
+    def __init__(self, snap: Optional[str] = None, name: Optional[str] = None) -> None:
+        self.snap = snap
+        self.name = name
 
 
 class Connection:
@@ -70,8 +67,8 @@ class Connection:
 class Snap(Package):
     def __init__(
         self,
-        snaps: str | List[str] = None,
-        local_snaps: str | List[str] = None,
+        snaps: Union[str, List[str]] = None,
+        local_snaps: Union[str, List[str]] = None,
         confinement: Confinement = Confinement.STRICT,
         channel: str = None,
         cohort: str = None,

--- a/src/cleantest/provider/_handler/base_handler.py
+++ b/src/cleantest/provider/_handler/base_handler.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022 Jason C. Nucciarone, Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Abstractions and utilities for test environment providers."""
-
-from __future__ import annotations
 
 import inspect
 import os
@@ -14,8 +12,8 @@ import tarfile
 import tempfile
 import textwrap
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import Any, Callable, Dict, List
+from collections import namedtuple
+from typing import Any, Dict, List, Union
 
 import cleantest
 
@@ -24,11 +22,7 @@ class HandlerError(Exception):
     ...
 
 
-@dataclass
-class Result:
-    exit_code: int = None
-    stdout: Any = None
-    stderr: Any = None
+Result = namedtuple("Result", ["exit_code", "stdout", "stderr"])
 
 
 class Entrypoint(ABC):
@@ -94,7 +88,9 @@ class Handler(ABC):
             )
         )
 
-    def _construct_testlet(self, src: str, name: str, remove: List[re.Pattern] | None) -> str:
+    def _construct_testlet(
+        self, src: str, name: str, remove: Union[List[re.Pattern], None]
+    ) -> str:
         """Construct Python source file to be run in subroutine.
 
         Args:

--- a/src/cleantest/provider/_handler/lxd_handler.py
+++ b/src/cleantest/provider/_handler/lxd_handler.py
@@ -8,7 +8,6 @@ import inspect
 import json
 import os
 import re
-import sys
 from concurrent.futures import ProcessPoolExecutor
 from typing import Any, Callable, Dict, List
 
@@ -17,8 +16,6 @@ from pylxd import Client
 from cleantest.pkg._base import Package
 from cleantest.provider._handler.base_handler import Entrypoint, Handler, Result
 from cleantest.provider.data.lxd_data import LXDConfig
-
-import pdb
 
 
 class Instance:
@@ -145,7 +142,6 @@ class Serial(Entrypoint, LXDHandler):
 class Parallel(Entrypoint, LXDHandler):
     def __init__(self, attr: Dict[str, Any], func: Callable) -> None:
         [setattr(self, k, v) for k, v in attr.items()]
-        print(dir(func), file=sys.stderr)
         self._func = inspect.getsource(func)
         self._func_name = func.__name__
 

--- a/src/cleantest/provider/_handler/lxd_handler.py
+++ b/src/cleantest/provider/_handler/lxd_handler.py
@@ -10,7 +10,6 @@ import os
 import re
 import sys
 from concurrent.futures import ProcessPoolExecutor
-from dataclasses import dataclass
 from typing import Any, Callable, Dict, List
 
 from pylxd import Client
@@ -19,12 +18,14 @@ from cleantest.pkg._base import Package
 from cleantest.provider._handler.base_handler import Entrypoint, Handler, Result
 from cleantest.provider.data.lxd_data import LXDConfig
 
+import pdb
 
-@dataclass
+
 class Instance:
-    name: str
-    image: str
-    exists: bool = False
+    def __init__(self, name: str, image: str, exists: bool = False) -> None:
+        self.name = name
+        self.image = image
+        self.exists = exists
 
 
 class LXDHandler(Handler):
@@ -164,7 +165,9 @@ class Parallel(Entrypoint, LXDHandler):
         self._build(self._check_exists(i))
         self._handle_start_env_hooks(i)
         result = self._execute(
-            self._construct_testlet(self._func, self._func_name, [re.compile(r"^@lxd\(([^)]+)\)")]),
+            self._construct_testlet(
+                self._func, self._func_name, [re.compile(r"^@lxd\(([^)]+)\)")]
+            ),
             i,
         )
         if self._preserve is False:

--- a/src/cleantest/provider/data/_mixins/__init__.py
+++ b/src/cleantest/provider/data/_mixins/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright 2022 Jason C. Nucciarone, Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from .dict_ops import DictOps

--- a/src/cleantest/provider/data/_mixins/dict_ops.py
+++ b/src/cleantest/provider/data/_mixins/dict_ops.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# Copyright 2022 Jason C. Nucciarone, Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Common operations needed by classes that aim to emulate dictionaries."""
+
+from typing import Dict
+
+
+class DictOps:
+    def dict(self) -> Dict:
+        return self._filterdict(self.__dict__)
+
+    def _filterdict(self, input_dict: Dict) -> Dict:
+        result = {}
+        for key, value in input_dict.items():
+            if hasattr(value, "__dict__"):
+                result.update({key: self._filterdict(value.__dict__)})
+            else:
+                result.update({key: value})
+
+        return result

--- a/src/cleantest/provider/data/env_data.py
+++ b/src/cleantest/provider/data/env_data.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022 Jason C. Nucciarone, Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Environment variable management for test providers."""
 
 import os
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 
 class EnvDataStore:
@@ -24,7 +24,7 @@ class EnvDataStore:
     def add(self, env_mapping: Dict[str, Any]) -> None:
         self.__env.update(env_mapping)
 
-    def get(self, env_var: str) -> Any | None:
+    def get(self, env_var: str) -> Union[Any, None]:
         """Retrieve environment variable from store.
 
         Args:

--- a/src/cleantest/provider/data/lxd_data.py
+++ b/src/cleantest/provider/data/lxd_data.py
@@ -1,53 +1,43 @@
 #!/usr/bin/env python3
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022 Jason C. Nucciarone, Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Information needed for LXD test provider."""
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel
+from ._mixins import DictOps
 
 
 class BadLXDConfigError(Exception):
     """Raised when the newly entered configuration fails the lint check."""
 
-    def __init__(self, config: Dict, desc: str = "Bad configuration for LXD instance.") -> None:
-        self.config = config
-        self.desc = desc
-        super().__init__(self.desc)
-
-    def __str__(self) -> str:
-        return f"{self.config}: {self.message}"
+    ...
 
 
 class LXDConfigNotFoundError(Exception):
     """Raised when the requested configuration for an LXD instance is not found in the registry."""
 
-    def __init__(self, name: str, desc: str = "Configuration not found in registry.") -> None:
+    ...
+
+
+class LXDSource:
+    def __init__(self, type: str, mode: str, server: str, protocol: str, alias: str) -> None:
+        self.type = type
+        self.mode = mode
+        self.server = server
+        self.protocol = protocol
+        self.alias = alias
+
+
+class LXDConfig(DictOps):
+    def __init__(self, name: str, source: LXDSource, project: Optional[str] = None) -> None:
         self.name = name
-        self.desc = desc
-        super().__init__(self.desc)
-
-    def __str__(self) -> str:
-        return f"{self.name}: {self.message}"
+        self.source = source
+        self.project = project
 
 
-class LXDSource(BaseModel):
-    type: str
-    mode: str
-    server: str
-    protocol: str
-    alias: str
-
-
-class LXDConfig(BaseModel):
-    name: str
-    source: LXDSource
-    project: str | None
-
-
-class Defaults(BaseModel):
+class Defaults:
     jammy_amd64: Dict[str, Any] = {
         "name": "jammy-amd64",
         "source": {

--- a/src/cleantest/provider/lxd.py
+++ b/src/cleantest/provider/lxd.py
@@ -4,37 +4,29 @@
 
 """LXD test environment provider functions and utilities."""
 
-from __future__ import annotations
-
 import os
-from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Tuple
+from collections import namedtuple
+from typing import Any, Callable, Dict, List, Union
 
 from cleantest.control.configurator import Configure
 from cleantest.provider.data import EnvDataStore, LXDDataStore
 
 from ._handler import LXDProvider, Result
 
-
-@dataclass
-class LXDClientConfig:
-    endpoint: Any = None
-    version: str = "1.0"
-    cert: Tuple[str, str] = None
-    verify: bool | str = True
-    timeout: float | Tuple[float, float] = None
-    project: str = "default"
+LXDClientConfig = namedtuple(
+    "LXDClientConfig", ["endpoint", "version", "cert", "verify", "timeout", "project"]
+)
 
 
 class lxd:
     def __init__(
         self,
         name: str = "test",
-        image: str | List[str] = ["jammy-amd64"],
+        image: Union[str, List[str]] = ["jammy-amd64"],
         preserve: bool = True,
         env: EnvDataStore = EnvDataStore(),
         data: LXDDataStore = LXDDataStore(),
-        image_config: Dict[str, Any] | List[Dict[str, Any]] = None,
+        image_config: Union[Dict[str, Any], List[Dict[str, Any]]] = None,
         client_config: LXDClientConfig = None,
         parallel: bool = False,
         num_threads: int = None,

--- a/src/cleantest/utils/__init__.py
+++ b/src/cleantest/utils/__init__.py
@@ -2,4 +2,4 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from cleantest.utils.detect_os import detect_os_variant
+from .detect_os import detect_os_variant

--- a/src/cleantest/utils/detect_os.py
+++ b/src/cleantest/utils/detect_os.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022 Jason C. Nucciarone, Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Detect operating system of test environment."""
@@ -25,7 +25,7 @@ def detect_os_variant() -> str:
 
 
 def _determine_linux() -> str:
-    os_release_data = [l.strip() for l in open("/etc/os-release", "rt")]
-    for l in os_release_data:
-        if l.startswith("ID="):
-            return l.split("=")[-1].lower()
+    os_release_data = [line.strip() for line in open("/etc/os-release", "rt")]
+    for line in os_release_data:
+        if line.startswith("ID="):
+            return line.split("=")[-1].lower()

--- a/tests/lxd/parallel/test_lxd_parallel.py
+++ b/tests/lxd/parallel/test_lxd_parallel.py
@@ -16,7 +16,7 @@ cleantest_config.register_hook(start_hook)
 
 @lxd(
     image=["jammy-amd64", "focal-amd64", "bionic-amd64"],
-    preserve=True,
+    preserve=False,
     parallel=True,
     num_threads=2,
 )
@@ -38,4 +38,7 @@ class TestParallelLXD:
     def test_parallel_lxd(self) -> None:
         results = install_tabulate()
         for name, result in results.items():
-            assert result.exit_code == 0
+            try:
+                assert result.exit_code == 0
+            except AssertionError:
+                raise Exception(f"{name} failed. Result: {result}")


### PR DESCRIPTION
This pull request adds support for Python 3.6 and up. This means that cleantest should be to run on Bionic Beaver, the oldest supported LTS version of Ubuntu (not considering extended support maintenance).

Changes:

* Remove `dataclass`
* Use `Union` instead of `|`
* Remove `from __future__ import annotations` from Python files.
* Fixed issues with parallel tests not working when running with less threads than instances that need to be tested.

Related issues:

Closes #16 