### PR TITLE
Add support for uploading and downloading files and directories

### DIFF
--- a/src/cleantest/hooks/data/directory.py
+++ b/src/cleantest/hooks/data/directory.py
@@ -8,7 +8,8 @@ import os
 import pathlib
 import tarfile
 import tempfile
-import zipfile
+from io import BytesIO
+from typing import Iterable
 
 from .file import File
 
@@ -25,24 +26,16 @@ class DirectoryNotFoundError(Exception):
     ...
 
 
+def _strip_tar(tar: tarfile.TarFile, n_components: int = 1) -> Iterable[tarfile.TarInfo]:
+    for member in tar.getmembers():
+        member_path = pathlib.Path(member.path)
+        member.path = member_path.relative_to(*member_path.parts[:n_components])
+        yield member
+
+
 class Dir(File):
-    def __init__(
-        self, src: str, dest: str, compression: str = "gz", overwrite: bool = False
-    ) -> None:
-        self.src = pathlib.Path(src)
-        self.dest = pathlib.Path(dest)
-        self.compression = compression
-        self.overwrite = overwrite
-        self._data = None
-
-        if self.src.is_file():
-            raise NotADirectoryError(f"{self.src} is a file. Use File class instead.")
-
-        if self.compression not in ["gz", "zip", "bz2", "xz", None]:
-            raise DirectoryError(
-                f"{self.compression} not valid compression format. "
-                f"Format can be one of the following: {['gz', 'zip', 'bz2', 'xz', None]}"
-            )
+    def __init__(self, src: str, dest: str, overwrite: bool = False) -> None:
+        super().__init__(src, dest, overwrite)
 
     def dump(self) -> None:
         if self.dest.exists() and self.overwrite is False:
@@ -53,32 +46,20 @@ class Dir(File):
         if self._data is None:
             DirectoryError("Nothing to write.")
 
-        if self.compression in ["gz", "bz2", "xz", None]:
-            protocol = "r" if self.compression is None else f"r:{self.compression}"
-            with tarfile.open(self._data, protocol) as tar:
-                tar.extractall(self.dest)
-        else:
-            with zipfile.ZipFile(self._data, "r") as zip_out:
-                zip_out.extractall(self.dest)
+        with tarfile.open(fileobj=BytesIO(self._data), mode="r:gz") as tar:
+            tar.extractall(self.dest, members=_strip_tar(tar))
 
     def load(self) -> None:
         if self.src.exists() is False:
             raise FileNotFoundError(f"Could not find {self.src}.")
 
+        if self.src.is_file():
+            raise NotADirectoryError(f"{self.src} is a file. Use File class instead.")
+
         old_dir = os.getcwd()
         os.chdir(os.sep.join(str(self.src).split(os.sep)[:-1]))
         archive_path = pathlib.Path(tempfile.gettempdir()).joinpath(self.src.name)
-        if self.compression in ["gz", "bz2", "xz", None]:
-            protocol = "w" if self.compression is None else f"w:{self.compression}"
-            with tarfile.open(archive_path, protocol) as tar:
-                tar.add(self.src.name)
-        else:
-            data = []
-            for root, directory, file in os.walk(os.getcwd()):
-                for filename in file:
-                    data.append(os.path.join(root, filename))
-            with zipfile.ZipFile(archive_path, "w") as zip_in:
-                for file in data:
-                    zip_in.write(file)
+        with tarfile.open(archive_path, "w:gz") as tar:
+            tar.add(self.src.name)
         os.chdir(old_dir)
         self._data = archive_path.read_bytes()

--- a/src/cleantest/hooks/startenv.py
+++ b/src/cleantest/hooks/startenv.py
@@ -13,7 +13,7 @@ class StartEnvHook:
     def __init__(
         self,
         name: str = "default",
-        packages: List[object] = [],
+        packages: List[Injectable] = [],
         upload: List[Injectable] = [],
     ) -> None:
         """Hook run at the start of the test environment.

--- a/src/cleantest/hooks/stopenv.py
+++ b/src/cleantest/hooks/stopenv.py
@@ -10,10 +10,12 @@ from cleantest.meta import Injectable
 
 
 class StopEnvHook:
-    def __init__(self, download: List[Injectable]) -> None:
+    def __init__(self, name: str = "default", download: List[Injectable] = []) -> None:
         """Hook run before stopping test environment.
 
         Args:
+            name (str): Unique name of hook.
             download (List[Injectable]): Artifacts to download from test environment.
         """
+        self.name = name
         self.download = download

--- a/tests/files/greeting.txt
+++ b/tests/files/greeting.txt
@@ -1,0 +1,1 @@
+Hello there General Kenobi

--- a/tests/files/greetings/greeting_1.txt
+++ b/tests/files/greetings/greeting_1.txt
@@ -1,0 +1,1 @@
+Good to see you.

--- a/tests/files/greetings/greeting_2.txt
+++ b/tests/files/greetings/greeting_2.txt
@@ -1,0 +1,1 @@
+What's cooking good-looking?

--- a/tests/files/greetings/greeting_3.txt
+++ b/tests/files/greetings/greeting_3.txt
@@ -1,0 +1,1 @@
+Stop! You have violated the law!

--- a/tests/files/test_upload_download.py
+++ b/tests/files/test_upload_download.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright 2022 Jason C. Nucciarone, Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Test that cleantest can successfully upload and download files."""
+
+import os
+import pathlib
+import tempfile
+
+from cleantest import Configure
+from cleantest.hooks import StartEnvHook, StopEnvHook
+from cleantest.hooks.data import Dir, File
+from cleantest.provider import lxd
+
+root = os.path.dirname(os.path.realpath(__file__))
+config = Configure()
+start_hook = StartEnvHook(
+    name="upload_artifact",
+    upload=[
+        File(os.path.join(root, "greeting.txt"), "/root/greeting.txt"),
+        Dir(os.path.join(root, "greetings"), "/root/greetings"),
+    ],
+)
+stop_hook = StopEnvHook(
+    name="download_artifact",
+    download=[
+        File("/root/dump.txt", os.path.join(tempfile.gettempdir(), "dump.txt")),
+        Dir("/root/dump", os.path.join(tempfile.gettempdir(), "dump")),
+    ],
+)
+config.register_hook(start_hook)
+config.register_hook(stop_hook)
+
+
+@lxd(image="jammy-amd64", preserve=True)
+def work_on_artifacts():
+    import os
+    import pathlib
+    import sys
+
+    print(pathlib.Path("/root/greeting.txt").is_file(), file=sys.stdout)
+    print(pathlib.Path("/root/dump").is_dir(), file=sys.stdout)
+
+    pathlib.Path("/root/dump.txt").write_text("Dumped like a sack of rocks")
+    os.mkdir("/root/dump")
+    pathlib.Path("/root/dump/dump_1.txt").write_text("Oh I have been dumped again!")
+
+
+class TestUploadDownload:
+    def test_upload_download(self) -> None:
+        work_on_artifacts()
+        assert pathlib.Path(tempfile.gettempdir()).joinpath("dump.txt").is_file() is True
+        assert pathlib.Path(tempfile.gettempdir()).joinpath("dump").is_dir() is True

--- a/tox.ini
+++ b/tox.ini
@@ -106,3 +106,11 @@ deps =
   pytest
 commands =
   pytest -v --tb native --log-cli-level=ERROR {[vars]tst_path}/packages/snap
+
+[testenv:files]
+description = Run functional tests to test file and directory injections.
+deps =
+  -r {toxinidir}/requirements.txt
+  pytest
+commands =
+  pytest -v --tb native --log-cli-level=ERROR {[vars]tst_path}/files


### PR DESCRIPTION
This pull request adds support for uploading and downloading files into test environments:

The following classes have been added:
* `File` - class responsible for uploading and downloading file objects. This class is used for standalone files.
* `Dir` - class responsible for uploading and downloading directory objects. This class is used for directories.

The following classes have been modified:
* `StopEnvHook` - finally added support for this hook! The `download` option is used to direct cleantest on what to download from the test environment.

### Related issues
Closes #18 