### PR TITLE
Stop blowing up `/tmp` directory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ The [Discussions](#discussions) page is a better place to get help for personal 
 * Please **do not** derail or troll issues. Keep the discussion on track and have respect for the other 
 users/contributors of cleantest.
 
-* Please **do not** post comments consisting soley of "+1", ":thumbsup:", or something similar. 
+* Please **do not** post comments consisting solely of "+1", ":thumbsup:", or something similar. 
 Use [GitHub's "reactions" feature](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) 
 instead.
   * The maintainers of cleantest reserve the right to delete comments that violate this rule.

--- a/src/cleantest/data/directory.py
+++ b/src/cleantest/data/directory.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2022 Jason C. Nucciarone, Canonical Ltd.
+# Copyright 2023 Jason C. Nucciarone
 # See LICENSE file for licensing details.
 
 """Abstractions for uploading and downloading directories from test environments."""
@@ -87,10 +87,10 @@ class Dir(File):
         if self.src.is_file():
             raise NotADirectoryError(f"{self.src} is a file. Use File class instead.")
 
-        old_dir = os.getcwd()
+        _ = os.getcwd()
         os.chdir(os.sep.join(str(self.src).split(os.sep)[:-1]))
-        archive_path = pathlib.Path(tempfile.gettempdir()).joinpath(self.src.name)
-        with tarfile.open(archive_path, "w:gz") as tar:
-            tar.add(self.src.name)
-        os.chdir(old_dir)
-        self._data = archive_path.read_bytes()
+        with tempfile.NamedTemporaryFile() as fin:
+            with tarfile.open(fin.name, "w:gz") as tar:
+                tar.add(self.src.name)
+            self._data = pathlib.Path(fin.name).read_bytes()
+        os.chdir(_)

--- a/src/cleantest/data/directory.py
+++ b/src/cleantest/data/directory.py
@@ -17,19 +17,13 @@ from cleantest.data.file import File
 class DirectoryError(Exception):
     """Base error for Dir class."""
 
-    ...
-
 
 class DirectoryExistsError(Exception):
     """Raised when a directory already exists on the host."""
 
-    ...
-
 
 class DirectoryNotFoundError(Exception):
     """Raised when a directory is not found on the host."""
-
-    ...
 
 
 def _strip_tar(tar: tarfile.TarFile, n_components: int = 1) -> Iterable[tarfile.TarInfo]:

--- a/src/cleantest/data/file.py
+++ b/src/cleantest/data/file.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2022 Jason C. Nucciarone, Canonical Ltd.
+# Copyright 2023 Jason C. Nucciarone
 # See LICENSE file for licensing details.
 
 """Abstractions for uploading and downloading files from test environments."""
@@ -10,6 +10,7 @@ import tarfile
 import tempfile
 import textwrap
 from io import BytesIO
+from typing import Dict
 
 from cleantest.meta import Injectable
 
@@ -17,13 +18,9 @@ from cleantest.meta import Injectable
 class FileError(Exception):
     """Base error for File class."""
 
-    ...
-
 
 class InjectableModeError(Exception):
-    """Raised when an invalid injection mode has been passed to __injectable__()."""
-
-    ...
+    """Raised when an invalid injection mode has been passed to `_injectable`."""
 
 
 class File(Injectable):
@@ -85,15 +82,15 @@ class File(Injectable):
         os.chdir(old_dir)
         self._data = archive_path.read_bytes()
 
-    def __injectable__(self, path: str, verification_hash: str, mode: str) -> str:
+    def _injectable(self, data: Dict[str, str], **kwargs) -> str:
         """Generate injectable script that will be run inside the test environment.
 
         Args:
-            path (str): Path to pickled object inside the test environment.
-            verification_hash (str): Hash to verify authenticity of pickled object.
-            mode (str):
-                "upload" - Uploading artifact into test environment.
-                "download" - Downloading artifact from the test environment.
+            data (Dict[str, str]): Data that needs to be in injectable script.
+                - checksum (str): SHA224 checksum to verify authenticity of object.
+                - data (str): Base64 encoded object to inject.
+            **kwargs:
+                mode (str): "push" or "pull" object to/from test environment instance.
 
         Raises:
             InjectableModeError: Raised if invalid mode has been passed.
@@ -101,18 +98,21 @@ class File(Injectable):
         Returns:
             (str): Injectable script.
         """
-        if mode == "upload":
+        _ = kwargs.get("mode", None)
+        if _ not in {"push", "pull"}:
+            InjectableModeError(f"Invalid mode: {_}. Please set mode to either 'push' or 'pull'.")
+        elif _ == "push":
             return textwrap.dedent(
                 f"""
                 #!/usr/bin/env python3
                 
                 from {self.__module__} import {self.__class__.__name__}
                 
-                holder = {self.__class__.__name__}._load("{path}", "{verification_hash}")
-                holder.dump()
+                _ = {self.__class__.__name__}._load("{data['checksum']}", "{data['data']}")
+                _.dump()
                 """
             ).strip("\n")
-        elif mode == "download":
+        else:
             return textwrap.dedent(
                 f"""
                 #!/usr/bin/env python3
@@ -121,12 +121,8 @@ class File(Injectable):
                 
                 from {self.__module__} import {self.__class__.__name__}
                 
-                holder = {self.__class__.__name__}._load("{path}", "{verification_hash}")
-                holder.load()
-                print(json.dumps(holder._dump()._asdict()), file=sys.stdout)
+                _ = {self.__class__.__name__}._load("{data['checksum']}", "{data['data']}")
+                _.load()
+                print(json.dumps(_._dump()), file=sys.stdout)
                 """
             ).strip("\n")
-        else:
-            InjectableModeError(
-                f"Invalid mode: {mode}. Please set mode to either 'upload' or 'download'."
-            )

--- a/src/cleantest/data/file.py
+++ b/src/cleantest/data/file.py
@@ -74,13 +74,13 @@ class File(Injectable):
         if self.src.is_dir():
             raise FileError(f"{self.src} is a directory. Use Dir class instead.")
 
-        old_dir = os.getcwd()
+        _ = os.getcwd()
         os.chdir(os.sep.join(str(self.src).split(os.sep)[:-1]))
-        archive_path = pathlib.Path(tempfile.gettempdir()).joinpath(self.src.name)
-        with tarfile.open(archive_path, "w:gz") as tar:
-            tar.add(self.src.name)
-        os.chdir(old_dir)
-        self._data = archive_path.read_bytes()
+        with tempfile.NamedTemporaryFile() as fin:
+            with tarfile.open(fin.name, "w:gz") as tar:
+                tar.add(self.src.name)
+            self._data = pathlib.Path(fin.name).read_bytes()
+        os.chdir(_)
 
     def _injectable(self, data: Dict[str, str], **kwargs) -> str:
         """Generate injectable script that will be run inside the test environment.

--- a/src/cleantest/meta/__init__.py
+++ b/src/cleantest/meta/__init__.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-# Copyright 2022 Jason C. Nucciarone, Canonical Ltd.
+# Copyright 2023 Jason C. Nucciarone
 # See LICENSE file for licensing details.
 
 from .base_handler import BaseEntrypoint, BaseHandler, BaseHandlerError, Result
 from .base_package import BasePackage, BasePackageError
 from .cleantest_info import CleantestInfo
-from .injectable import Injectable, InjectableData
+from .injectable import Injectable

--- a/src/cleantest/meta/injectable.py
+++ b/src/cleantest/meta/injectable.py
@@ -1,78 +1,66 @@
 #!/usr/bin/env python3
-# Copyright 2022 Jason C. Nucciarone, Canonical Ltd.
+# Copyright 2023 Jason C. Nucciarone
 # See LICENSE file for licensing details.
 
-"""Metaclass for objects that will be injected into environments."""
+"""Abstract base class for injectable objects."""
 
+import base64
 import hashlib
-import pathlib
 import pickle
-import tempfile
-import uuid
 from abc import ABC, abstractmethod
-from collections import namedtuple
+from typing import Dict
 
 
 class InjectionError(Exception):
     """Base error for classes that inherit from Injectable."""
-
-    ...
-
-
-# Namedtuple returned by the _dump() method that contains
-# the path to the dumped object and its verification hash for future loading.
-InjectableData = namedtuple("InjectableData", ["path", "hash"])
 
 
 class Injectable(ABC):
     """Abstract metaclass that provides core methods needed by all injectable objects."""
 
     @classmethod
-    def _load(cls, data: str, verification_hash: str) -> object:
-        """Alternative constructor to load previously created object.
+    def _load(cls, checksum: str, data: str) -> object:
+        """Alternative constructor to load previously initialized object.
 
         Args:
+            checksum (str): Checksum to verify authenticity of serialized object.
             data (str): Path to file containing serialized object.
-            verification_hash (str): Hash to verify authenticity of serialized object.
 
         Returns:
             (object): Deserialized, verified object.
         """
-        fin = pathlib.Path(data)
-        if type(data) == str and fin.exists() and fin.is_file():
-            if verification_hash != hashlib.sha224(fin.read_bytes()).hexdigest():
-                raise InjectionError("Hashes do not match. Will not load untrusted object.")
+        if type(data) != str:
+            raise InjectionError(f"Cannot load object {data}. {type(data)} != str")
 
-            cls_data = pickle.loads(fin.read_bytes())
-            posargs = [
-                value for key, value in cls_data.__dict__.items() if not key.startswith("_")
-            ]
-            hiddenargs = {
-                key: value for key, value in cls_data.__dict__.items() if key.startswith("_")
-            }
-            new_cls = cls(*posargs)
-            [setattr(new_cls, key, value) for key, value in hiddenargs.items()]
-            return new_cls
-        else:
-            raise InjectionError(
-                f"Cannot load object {data}. Cannot find pickle file or {type(data)} is not str."
-            )
+        _ = base64.b64decode(data)
+        if checksum != hashlib.sha224(_).hexdigest():
+            raise InjectionError("Hashes do not match. Will not load untrusted object.")
 
-    def _dump(self) -> InjectableData:
-        """Serialize object and generate SHA224 hash for verification.
+        _ = pickle.loads(_)
+        posargs = [value for key, value in _.__dict__.items() if not key.startswith("_")]
+        hiddenargs = {key: value for key, value in _.__dict__.items() if key.startswith("_")}
+        new_cls = cls(*posargs)
+        [setattr(new_cls, key, value) for key, value in hiddenargs.items()]
+        return new_cls
+
+    def _dump(self, **kwargs) -> Dict[str, str]:
+        """Prepare object for injection.
 
         Returns:
-            (InjectableData):
-                path (str): Path to file containing serialized object.
-                hash (str): Hash to verify authenticity of serialized object.
+            (Dict[str, str]):
+                checksum (str): Checksum to verify authenticity of serialized object.
+                data (str): Base64 encoded string containing serialized object.
+                injectable (str): Injectable to run inside remote environment.
         """
-        fout = pathlib.Path(tempfile.gettempdir()).joinpath(f"{uuid.uuid4()}.pkl")
-        data = pickle.dumps(self)
-        fout.write_bytes(data)
-        verification_hash = hashlib.sha224(data).hexdigest()
-        return InjectableData(str(fout), verification_hash)
+        pickle_data = pickle.dumps(self)
+        checksum = hashlib.sha224(pickle_data).hexdigest()
+        data = base64.b64encode(pickle_data).decode()
+        return {
+            "checksum": checksum,
+            "data": data,
+            "injectable": self._injectable({"checksum": checksum, "data": data}, **kwargs),
+        }
 
     @abstractmethod
-    def __injectable__(self) -> str:
-        """Generate script that will be injected into test environment provider."""
-        ...
+    def _injectable(self, data: Dict[str, str], **kwargs) -> str:
+        """Python script to run inside of test environment provider."""

--- a/src/cleantest/provider/lxd/lxd_handler.py
+++ b/src/cleantest/provider/lxd/lxd_handler.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
-# Copyright 2023 Jason C. Nucciarone, Canonical Ltd.
+# Copyright 2023 Jason C. Nucciarone
 # See LICENSE file for licensing details.
 
 """Handler for LXD test environments."""
 
 import inspect
 import json
-import pathlib
 import re
 import tempfile
 from concurrent.futures import ProcessPoolExecutor
@@ -96,14 +95,13 @@ class LXDHandler(BaseHandler):
             instance (Any): Instance to initialize.
         """
         meta = CleantestInfo()
-        instance.execute(["mkdir", "-p", "/root/init"])
-        for module, src in {**meta.src, **meta.dependencies}.items():
-            instance.files.put(f"/root/init/{module}.tar.gz", src)
+        instance.execute(["mkdir", "-p", "/root/init/cleantest"])
+        for name, data in meta.dump():
             instance.files.put(
-                f"/root/init/install_{module}",
-                meta.make_pkg_injectable(f"/root/init/{module}.tar.gz"),
+                f"/root/init/cleantest/install_{name}",
+                data["injectable"],
             )
-            instance.execute(["python3", f"/root/init/install_{module}"])
+            instance.execute(["python3", f"/root/init/cleantest/install_{name}"])
 
     def _execute(self, test: str, instance: InstanceMetadata) -> Any:
         """Execute a testlet inside an LXD test environment instance.

--- a/src/cleantest/utils/run.py
+++ b/src/cleantest/utils/run.py
@@ -38,9 +38,10 @@ def run(
                 command.split(" "),
                 env=(env if env else None),
                 cwd=(cwd if cwd else None),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                universal_newlines=True,
                 check=True,
-                capture_output=True,
-                text=True,
             )
         except subprocess.CalledProcessError as e:
             raise CommandExecutionError(f"Failed to execute command {command}. Reason: {e}.")

--- a/tests/files/test_upload_download.py
+++ b/tests/files/test_upload_download.py
@@ -8,9 +8,9 @@ import os
 import pathlib
 import tempfile
 
-from cleantest import Configure
-from cleantest.hooks import StartEnvHook, StopEnvHook
-from cleantest.hooks.data import Dir, File
+from cleantest.control import Configure
+from cleantest.control.hooks import StartEnvHook, StopEnvHook
+from cleantest.data import Dir, File
 from cleantest.provider import lxd
 
 root = os.path.dirname(os.path.realpath(__file__))
@@ -32,7 +32,7 @@ stop_hook = StopEnvHook(
 config.register_hook(start_hook, stop_hook)
 
 
-@lxd(image="jammy-amd64", preserve=True)
+@lxd(image="ubuntu-jammy-amd64", preserve=True)
 def work_on_artifacts():
     import os
     import pathlib

--- a/tests/lxd/parallel/test_lxd_parallel.py
+++ b/tests/lxd/parallel/test_lxd_parallel.py
@@ -4,9 +4,9 @@
 
 """Test parallel testing capabilities of LXD provider using local LXD cluster."""
 
-from cleantest import Configure
-from cleantest.hooks import StartEnvHook
-from cleantest.pkg import Pip
+from cleantest.control import Configure
+from cleantest.control.hooks import StartEnvHook
+from cleantest.data.pkg import Pip
 from cleantest.provider import lxd
 
 cleantest_config = Configure()
@@ -15,7 +15,7 @@ cleantest_config.register_hook(start_hook)
 
 
 @lxd(
-    image=["jammy-amd64", "focal-amd64", "bionic-amd64"],
+    image=["ubuntu-jammy-amd64", "ubuntu-focal-amd64", "ubuntu-bionic-amd64"],
     preserve=False,
     parallel=True,
     num_threads=2,

--- a/tests/packages/snap/test_snap.py
+++ b/tests/packages/snap/test_snap.py
@@ -6,9 +6,9 @@
 
 import os
 
-from cleantest import Configure
-from cleantest.hooks import StartEnvHook
-from cleantest.pkg import Connection, Plug, Slot, Snap
+from cleantest.control import Configure
+from cleantest.control.hooks import StartEnvHook
+from cleantest.data.pkg import Connection, Plug, Slot, Snap
 from cleantest.provider import lxd
 
 root = os.path.dirname(os.path.realpath(__file__))
@@ -28,7 +28,7 @@ start_hook = StartEnvHook(
 config.register_hook(start_hook)
 
 
-@lxd(image="jammy-amd64", preserve=False)
+@lxd(image="ubuntu-jammy-amd64", preserve=False)
 def functional_snaps():
     import sys
     from shutil import which


### PR DESCRIPTION
This pull request fixes #21 where cleantest blows up `/tmp` if the host system running cleantest is not rebooted. This fix was implemented by updating how cleantest sends data to the test environment instance, and by using NamedTemporaryFile's rather than just located tempdir. This should prevent cleantest from accidentally filling up the primary drive.

### Related issues

Closes #21 