### PR TITLE
Add templates for issues and pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,70 @@
+# Copyright 2023 Jason C. Nucciarone
+# See LICENSE file for licensing details.
+
+name: Bug Report
+description: File a bug report for cleantest
+title: "[Bug]: "
+labels: ["Type: Bug", "Type: Triage"]
+assignees:
+  - NucciTheBoss
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thank you for taking the time to fill out this bug report against cleantest!
+        Please be sure to fill out the following sections.
+  - type: textarea
+    id: description-of-bug
+    attributes:
+      label: Describe the bug you encountered using cleantest
+      description: Also, please describe what you expected to happen.
+      placeholder: Tell me what you see!
+    validations:
+      required: true
+  - type: textarea
+    id: system-info
+    attributes:
+      label: System Info
+      description: |
+        examples:
+          - __operating system__: Ubuntu 22.04 LTS
+          - __cleantest version__: 0.3.0
+          - __test environment provider__: LXD 5.9
+          - __Python version__: 3.10.6
+      value: |
+          - operating system:
+          - cleantest version:
+          - test environment provider:
+          - Python version:
+      render: markdown
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Please provide the steps to reproduce the error.
+      placeholder: |
+        1. With this test environment provider...
+        2. With this testlet...
+        3. Run...
+        4. See error...
+  - type: textarea
+    id: additional-information
+    attributes:
+      label: Any additional information that you would like to share with me?
+      description: |
+        Links? References? Anything that will give me more context about the bug you are encountering!
+
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: >
+        By filing this bug report, you agree to follow cleantest's 
+        [Code of Conduct](../../CODE_OF_CONDUCT.md) when interacting
+        with the project maintainers.
+      options:
+        - label: I agree to follow cleantest's Code of Conduct
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!-- Copyright 2023 Jason C. Nucciarone -->
+<!-- See LICENSE file for licensing details. -->
+
+## Description
+
+> Provide a description of the purpose of this pull request, as well as its motivation 
+> and context. Is it a new feature to add to cleantest? A bug fix? 
+> Does it address an issue brought up in discussions and/or the issue tracker?
+
+## How was the code tested?
+
+> Describe how you tested cleantest with your contributions added.
+>
+> * Did you run the functional tests in `tests/`?
+> * Did you write new tests for cleantest? Where in `tests/` are they located?
+> * Which test environment provider did you use for the tests? LXD?
+> * What operating system did you test cleantest on? Ubuntu 22.04, Ubuntu 20.04, Fedora 36, etc.
+
+## Related issues, discussions, project board tasks, etc.
+
+## Contributor Agreement
+
+- [ ] I agree to license my contributions under the [Apache Software License, version 2.0](../LICENSE), should my contributions be accepted by the maintainers of cleantest.
+- [ ] I agree to follow the cleantest [Code of Conduct](../CODE_OF_CONDUCT.md) while engaging with cleantest's maintainers on this pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,16 +70,16 @@ you for taking the time to report issues in the source code!
 
 Guidelines for reporting bugs in cleantest:
 
-1. **Validate your testlet** &mdash; ensure that your issue is not being caused by either a semantic or syntactic 
+1. __Validate your testlet__ &mdash; ensure that your issue is not being caused by either a semantic or syntactic 
 error in your testlet's code.
 
-2. **Validate your hypervisor** &mdash; ensure that your issue is not being caused by a misconfiguration in the
+2. __Validate your hypervisor__ &mdash; ensure that your issue is not being caused by a misconfiguration in the
 test environment provider that you are using with cleantest.
 
-3. **Use the GitHub issue search** &mdash; check if the issue you are encountering has already been reported by 
+3. __Use the GitHub issue search__ &mdash; check if the issue you are encountering has already been reported by 
 someone else.
 
-4. **Check if the issue has already been fixed** &mdash; try to reproduce your issue using the latest `main` 
+4. __Check if the issue has already been fixed__ &mdash; try to reproduce your issue using the latest `main` 
 in the cleantest repository.
 
 5. **Isolate the problem** &mdash; the more pinpointed the issue is, the easier time the cleantest developers 
@@ -90,40 +90,6 @@ Please try to be as detailed as possible in your report. What is your environmen
 What operating system are you experiencing the problem on? Have you had the same results on a different 
 operating system? What would you expect to be the outcome? All these details will help the developers fix any 
 potential bugs.
-
-Example Bug Report:
-
-> Short and descriptive bug report title
-> 
-> ### System Info:
->  - Operating system: [e.g. Ubuntu 22.04 LTS (Jammy Jellyfish)]
->  - Cleantest version: [e.g. 0.3.0]
->  - Hypervisor version: [e.g. LXD 5.9] 
->  - Python version: [e.g. 3.10.1]
-> 
-> ### Describe the bug:
-> A clear and concise description of the bug you are encountering.
-> 
-> ### Copy of stacktrace:
-> ```
-> Copy of stack printed out to command line or log file by cleantest.
-> ```
-> 
-> ### Steps to Reproduce:
-> Steps to reproduce the behavior:
-> 1. Configuration options passed
-> 2. Testlets run
-> 3. Stage of pipeline
-> 4. See error
-> 
-> ### Expected Behavior:
-> A clear and concise description of what you expected to happen.
-> 
-> ### Screenshots:
-> If applicable, add screenshots to help explain your problem.
-> 
-> #### Additional context:
-> Add any other context about the problem here.
 
 ## Feature Requests
 
@@ -141,7 +107,7 @@ a temporary ban from the repository.
 Good pull requests &mdash; patches, improvements, new features &mdash; are a huge help. These pull requests should 
 remain focused in scope and should not contain unrelated commits.
 
-**Ask first** before embarking on any **significant** pull request (eg. implementing new features, refactoring code, 
+__Ask first__ before embarking on any __significant__ pull request (e.g. implementing new features, refactoring code, 
 incorporating a new test environment provider, etc.), otherwise you risk spending a lot of time working on something 
 that cleantest's developers might not want to merge into the project! For trivial things, or things that do not require 
 a lot of your time, you can go ahead and make a pull request.
@@ -196,14 +162,14 @@ included in the project:
 7. [Open a Pull Request](https://help.github.com/articles/about-pull-requests/)
     with a clear title and description against the `main` branch.
 
-**IMPORTANT**: By submitting a patch, improvement, or new feature, you agree to allow the owners of cleantest to 
+**IMPORTANT**: By submitting a patch, improvement, or new feature, you agree to allow the maintainers of cleantest to 
 license your contributions under the terms of the [Apache 2.0 license](./LICENSE).
 
 ## Discussions
 
 GitHub's discussions are a great place to connect with other users of cleantest as well as discuss potential 
 features and resolve personal support questions. It is expected that the users of cleantest remain respectful of 
-each other. Discussion moderators reserve the right the suspend discussions and/or delete posts that do not follow 
+each other. Discussion moderators reserve the right to suspend discussions and/or delete posts that do not follow 
 this rule.
 
 ## Code guidelines


### PR DESCRIPTION
This pull request adds new templates for bug reports and pull requests to help streamline the contribution process, and make things easier on me when others make contributions.

### Related issues

Closes #34 