### PR TITLE
Implement strategy pattern for LXD provider entrypoint

### DIFF
--- a/src/cleantest/meta/__init__.py
+++ b/src/cleantest/meta/__init__.py
@@ -7,7 +7,12 @@
 You can use these modules for developing third-party plugins.
 """
 
-from .base_handler import BaseEntrypoint, BaseHandler, BaseHandlerError
+from .base_handler import (
+    BaseEntrypoint,
+    BaseEntrypointError,
+    BaseHandler,
+    BaseHandlerError,
+)
 from .base_package import BasePackage, BasePackageError
 from .cleantest_info import CleantestInfo
 from .injectable import Injectable

--- a/src/cleantest/meta/__init__.py
+++ b/src/cleantest/meta/__init__.py
@@ -2,7 +2,13 @@
 # Copyright 2023 Jason C. Nucciarone
 # See LICENSE file for licensing details.
 
-from .base_handler import BaseEntrypoint, BaseHandler, BaseHandlerError, Result
+"""Public metaclasses used inside cleantest.
+
+You can use these modules for developing third-party plugins.
+"""
+
+from .base_handler import BaseEntrypoint, BaseHandler, BaseHandlerError
 from .base_package import BasePackage, BasePackageError
 from .cleantest_info import CleantestInfo
 from .injectable import Injectable
+from .result import Result

--- a/src/cleantest/meta/base_handler.py
+++ b/src/cleantest/meta/base_handler.py
@@ -12,6 +12,10 @@ from typing import Any, Dict, List
 from .result import Result
 
 
+class BaseEntrypointError(Exception):
+    """Base error for test run entrypoints."""
+
+
 class BaseHandlerError(Exception):
     """Base error for test environment handlers."""
 
@@ -34,19 +38,19 @@ class BaseHandler(ABC):
     """
 
     @abstractmethod
-    def exists(self) -> bool:
+    def _exists(self) -> bool:
         """Check if test environment already exists."""
 
     @abstractmethod
-    def init(self) -> None:
+    def _init(self) -> None:
         """Build and initialize test environment instance."""
 
     @abstractmethod
-    def execute(self) -> Result:
+    def _execute(self) -> Result:
         """Execute testlet inside test environment instance."""
 
     @abstractmethod
-    def teardown(self) -> None:
+    def _teardown(self) -> None:
         """Destroy test environments if not told to preserve."""
 
     @abstractmethod

--- a/src/cleantest/meta/base_handler.py
+++ b/src/cleantest/meta/base_handler.py
@@ -1,24 +1,19 @@
 #!/usr/bin/env python3
-# Copyright 2022 Jason C. Nucciarone, Canonical Ltd.
+# Copyright 2023 Jason C. Nucciarone
 # See LICENSE file for licensing details.
 
-"""Metaclass for objects that will serve as handlers for test environments."""
+"""Abstract class for test environment instance handlers."""
 
 import re
 import tempfile
 from abc import ABC, abstractmethod
-from collections import namedtuple
 from typing import Any, Dict, List
+
+from .result import Result
 
 
 class BaseHandlerError(Exception):
     """Base error for test environment handlers."""
-
-    ...
-
-
-# Base result class that should be used by all test environments.
-Result = namedtuple("Result", ["exit_code", "stdout", "stderr"])
 
 
 class BaseEntrypoint(ABC):
@@ -30,7 +25,6 @@ class BaseEntrypoint(ABC):
     @abstractmethod
     def run(self) -> Dict[str, Result]:
         """Run handler for test environment."""
-        ...
 
 
 class BaseHandler(ABC):
@@ -40,44 +34,28 @@ class BaseHandler(ABC):
     """
 
     @abstractmethod
-    def _exists(self) -> None:
+    def exists(self) -> bool:
         """Check if test environment already exists."""
-        ...
 
     @abstractmethod
-    def _build(self) -> None:
-        """Build test environments."""
-        ...
+    def init(self) -> None:
+        """Build and initialize test environment instance."""
 
     @abstractmethod
-    def _init(self) -> None:
-        """Inject cleantest and dependencies into test environments."""
-        ...
+    def execute(self) -> Result:
+        """Execute testlet inside test environment instance."""
 
     @abstractmethod
-    def _execute(self) -> Any:
-        """Execute testlet inside container."""
-        ...
-
-    @abstractmethod
-    def _process(self) -> Result:
-        """Process result from testlet."""
-        ...
-
-    @abstractmethod
-    def _teardown(self) -> None:
+    def teardown(self) -> None:
         """Destroy test environments if not told to preserve."""
-        ...
 
     @abstractmethod
     def _handle_start_env_hooks(self) -> None:
         """Handle StartEnv hooks."""
-        ...
 
     @abstractmethod
     def _handle_stop_env_hooks(self) -> None:
         """Handle StopEnv hooks."""
-        ...
 
     def _make_testlet(self, src: str, name: str, remove: List[Any] = None) -> str:
         """Construct Python source file to be run in subroutine.
@@ -97,14 +75,14 @@ class BaseHandler(ABC):
             for pattern in remove:
                 src = re.sub(pattern, "", src)
 
-        with tempfile.TemporaryFile(mode="w+t") as f:
+        with tempfile.TemporaryFile(mode="w+t") as _:
             content = [
                 "#!/usr/bin/env python3\n",
                 f"{src}\n",
                 f"{name}()\n",
             ]
-            f.writelines(content)
-            f.seek(0)
-            testlet = f.read()
+            _.writelines(content)
+            _.seek(0)
+            testlet = _.read()
 
         return testlet

--- a/src/cleantest/meta/result.py
+++ b/src/cleantest/meta/result.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# Copyright 2023 Jason C. Nucciarone
+# See LICENSE file for licensing details.
+
+"""Result class for cleantest methods that return data."""
+
+from typing import Any
+
+
+class Result:
+    """Result containing exit code, stdout, and stderr.
+
+    Args:
+        exit_code (int): Captured exit code.
+        stdout (Any): Captured data printed to standard output.
+        stderr (Any): Captured data printed to standard error.
+    """
+
+    def __init__(self, exit_code: int, stdout: Any, stderr: Any):
+        self.__exit_code = exit_code
+        self.__stdout = stdout
+        self.__stderr = stderr
+
+    @property
+    def exit_code(self) -> int:
+        """Return captured exit_code."""
+        return self.__exit_code
+
+    @property
+    def stdout(self) -> Any:
+        """Return captured stdout."""
+        return self.__stdout
+
+    @property
+    def stderr(self) -> Any:
+        """Return captured stderr."""
+        return self.__stderr
+
+    def __repr__(self) -> str:
+        """String representation of Result."""
+        return (
+            f"{self.__class__.__name__}(exit_code={self.__exit_code}, "
+            f"stdout={self.__stdout}, stderr={self.__stderr})"
+        )

--- a/tests/functional/files/test_upload_download.py
+++ b/tests/functional/files/test_upload_download.py
@@ -54,6 +54,8 @@ def test_upload_download(clean_slate) -> None:
         ],
     )
     config.register_hook(start_hook, stop_hook)
-    work_on_artifacts()
-    assert pathlib.Path(tempfile.gettempdir()).joinpath("dump.txt").is_file() is True
-    assert pathlib.Path(tempfile.gettempdir()).joinpath("dump").is_dir() is True
+    for name, result in work_on_artifacts():
+        assert (
+            pathlib.Path(tempfile.gettempdir()).joinpath("dump.txt").is_file() is True
+        )
+        assert pathlib.Path(tempfile.gettempdir()).joinpath("dump").is_dir() is True

--- a/tests/functional/lxd/local/test_lxd_local.py
+++ b/tests/functional/lxd/local/test_lxd_local.py
@@ -61,6 +61,5 @@ def test_local_lxd(clean_slate) -> None:
         ],
     )
     config.register_hook(start_hook)
-    results = install_snapd()
-    for name, result in results.items():
+    for name, result in install_snapd():
         assert result.exit_code == 0

--- a/tests/functional/lxd/parallel/test_lxd_parallel.py
+++ b/tests/functional/lxd/parallel/test_lxd_parallel.py
@@ -34,8 +34,7 @@ def test_parallel_lxd(clean_slate) -> None:
     config = Configure("lxd")
     start_hook = StartEnvHook(name="pip_injection", packages=[Pip(packages="tabulate")])
     config.register_hook(start_hook)
-    results = install_tabulate()
-    for name, result in results.items():
+    for name, result in install_tabulate():
         try:
             assert result.exit_code == 0
         except AssertionError:

--- a/tests/functional/packages/snap/test_snap.py
+++ b/tests/functional/packages/snap/test_snap.py
@@ -47,6 +47,5 @@ def test_snap_package(clean_slate) -> None:
         ],
     )
     config.register_hook(start_hook)
-    results = functional_snaps()
-    for name, result in results.items():
+    for name, result in functional_snaps():
         assert result.exit_code == 0


### PR DESCRIPTION
<!-- Copyright 2023 Jason C. Nucciarone -->
<!-- See LICENSE file for licensing details. -->

## Description

This pull requests implements a strategy pattern for configuring the `LXDProviderEntrypoint` class at runtime. Rather than having a standalone entrypoint class returned based on the constructor invoked by `lxd`, a strategy is passed which configures which method is set as the `run` method.

This pull requests also adds a more enhanced `Result` class rather than just being a namedtuple. Also it removes the _process method from `BaseHandler` since_process was not that useful and added more complexity.

## How was the code tested?

Ran the functional tests on my Ubuntu 22.04 workstation.

## Related issues, discussions, project board tasks, etc.

Closes #31 

## Contributor Agreement

- [x] I agree to license my contributions under the [Apache Software License, version 2.0](../LICENSE), should my contributions be accepted by the maintainers of cleantest.
- [x] I agree to follow the cleantest [Code of Conduct](../CODE_OF_CONDUCT.md) while engaging with cleantest's maintainers on this pull request.
