### PR TITLE
update canonical/setup-lxd to v0.1.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
         env:
           CHARMCRAFT_AUTH_TOKEN: ${{ secrets.CHARMCRAFT_AUTH_TOKEN }}
       - name: Setup LXD test environment provider
-        uses: canonical/setup-lxd@v0.1.0
+        uses: canonical/setup-lxd@v0.1.1
         with:
           channel: 5.9/stable
       - name: Run functional tests


### PR DESCRIPTION
<!-- Copyright 2023 Jason C. Nucciarone -->
<!-- See LICENSE file for licensing details. -->

## Description

There is a bug in canonical/setup-lxd@v0.1.0 where the `channel` input is ignored. This has been fixed in v0.1.1. See https://github.com/canonical/setup-lxd/pull/8

## Contributor Agreement

- [x] I agree to license my contributions under the [Apache Software License, version 2.0](../LICENSE), should my contributions be accepted by the maintainers of cleantest.
- [x] I agree to follow the cleantest [Code of Conduct](../CODE_OF_CONDUCT.md) while engaging with cleantest's maintainers on this pull request.
